### PR TITLE
Apply defined-array.patch from Debian package

### DIFF
--- a/gtml
+++ b/gtml
@@ -1610,7 +1610,7 @@ sub ProcessSourceFile
     #
     # Process source files only if asked.
     #
-    if ( defined(@fileToProcess) && ! (&Member($name, @fileToProcess)) )
+    if (@fileToProcess && ! (&Member($name, @fileToProcess)) )
     {
         return;
     }


### PR DESCRIPTION
This PR applies `defined-array.patch` from the Debian package, which is tied to [Debian bug #739905](http://bugs.debian.org/739905).

Starting with Perl v5.18.2 (back in 2014), we started seeing deprecation warnings like `defined(@array) is deprecated at /usr/bin/gtml line 1613`.  At the time, I touched base with Andrew, and he suggested the fix in this PR based on notes in
 http://perldoc.perl.org/functions/defined.html.