### PR TITLE
Apply include-literal.patch from Debian package

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -89,6 +89,10 @@ The name of the file can be defined in a named constant, as described next.
 
 The directories in which the file may be looked for can be defined in a special named constant.
 
+### `#includeliteral`
+
+Works the same as `#include` but also turns on `#literal` so GTML does not interpret a given file, just includes it.
+
 ### `#define`
 
 This is a simple way to create shorthand definitions - what we call _named constants_, or _macros_ - for your frequently-used text. For some text which you use often - say, an e-mail address - include a line like this:

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -91,7 +91,7 @@ The directories in which the file may be looked for can be defined in a special 
 
 ### `#includeliteral`
 
-Works the same as `#include` but also turns on `#literal` so GTML does not interpret a given file, just includes it.  This is equivalent to putting `#literal ON` as first line of the included file and then `#literal OFF` as the last line of the included file.
+Works the same as `#include` but also turns on `#literal` so GTML does not interpret a given file, just includes it.  This is equivalent to putting `#literal ON` as the first line of the included file and then `#literal OFF` as the last line of the included file.
 
 ### `#define`
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -91,7 +91,7 @@ The directories in which the file may be looked for can be defined in a special 
 
 ### `#includeliteral`
 
-Works the same as `#include` but also turns on `#literal` so GTML does not interpret a given file, just includes it.
+Works the same as `#include` but also turns on `#literal` so GTML does not interpret a given file, just includes it.  This is equivalent to putting `#literal ON` as first line of the included file and then `#literal OFF` as the last line of the included file.
 
 ### `#define`
 

--- a/gtml
+++ b/gtml
@@ -1911,6 +1911,11 @@ sub ProcessLines
         #
         elsif ( /^#include/ )
         {
+            local( $my_prev_literal_setting ) = $literal;
+            if( /^#includeliteral/ )
+            {
+                $literal = 1;
+            }
             chop;
             if ( $compression ) 
             { 
@@ -1918,7 +1923,7 @@ sub ProcessLines
             }
 
             &Substitute();
-            s/^#include[ \t]*"//;
+            s/^#include(literal)?[ \t]*"//;
             s/".*$//; #"
             $file = $_;
             $file = &ResolveIncludeFile($file);
@@ -1928,6 +1933,7 @@ sub ProcessLines
 # TODO #                &Notice("    --- $file\n");
                 &ProcessLines($file);
             }
+            $literal = $my_prev_literal_setting;
             next;
         }
         #


### PR DESCRIPTION
This PR applies `include-literal.patch` from the Debian package, which is tied to [Debian bug #340963](http://bugs.debian.org/340963) from 2005.   The original author was Flavio Stanchina.  The patch has been adjusted to update `REFERENCE.md` rather than the original HTML documentation. 